### PR TITLE
chore(docker): add mysql 8 + adminer via docker compose

### DIFF
--- a/carshop/bun.lock
+++ b/carshop/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "carshop",
@@ -17,7 +18,7 @@
         "react-hot-toast": "^2.5.2",
         "swiper": "^11.2.8",
         "yet-another-react-lightbox": "^3.23.3",
-        "zustand": "^5.0.5",
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -25,9 +26,9 @@
         "@tailwindcss/postcss": "^4",
         "eslint": "^9",
         "eslint-config-next": "15.2.3",
-        "tailwindcss": "^4",
-      },
-    },
+        "tailwindcss": "^4"
+      }
+    }
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -930,6 +931,6 @@
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="]
   }
 }

--- a/carshop/docker-compose.yml
+++ b/carshop/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: carshop-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASS}
+      TZ: Europe/Berlin
+    ports:
+      - "${DB_PORT:-3306}:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+
+  adminer:
+    image: adminer:latest
+    container_name: carshop-adminer
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
## Description
Set up local development infrastructure using Docker Compose with MySQL 8.0 and Adminer.
Also updated the lockfile after installing dependencies with Bun.

## Changes
- Added `docker-compose.yml` with:
  - MySQL 8.0 service
  - Persistent volume for database data
  - Adminer service for local database management
- Updated `bun.lock` after running `bun install`

## Why?
Previously, the project relied on **Open Server Panel** to run MySQL locally.
This change migrates the database setup to **Docker** to provide a more reproducible,
portable, and platform-independent environment.

Docker-based infrastructure simplifies future development, reduces setup friction,
and improves long-term maintainability.

## Notes
- Environment files (`.env`, `.env.local`) and SQL dumps are intentionally not committed.
- This setup is intended for local development only.
