### PR TITLE
chore(deps): bump dotenv to v17

### DIFF
--- a/carshop/bun.lock
+++ b/carshop/bun.lock
@@ -6,7 +6,7 @@
       "name": "carshop",
       "dependencies": {
         "@headlessui/react": "^2.2.9",
-        "dotenv": "^16.6.1",
+        "dotenv": "^17.2.3",
         "framer-motion": "^12.25.0",
         "lucide-react": "^0.562.0",
         "mysql2": "^3.16.0",
@@ -397,7 +397,7 @@
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
-    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+    "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/carshop/package.json
+++ b/carshop/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",
-    "dotenv": "^16.6.1",
+    "dotenv": "^17.2.3",
     "framer-motion": "^12.25.0",
     "lucide-react": "^0.562.0",
     "mysql2": "^3.16.0",


### PR DESCRIPTION
## Description
Upgrade `dotenv` to v17.

## Why?
Keeps the project dependencies current and reduces future upgrade friction.

## Notes
- This PR is intentionally scoped to a single dependency update
