### PR TITLE
chore(deps): bump swiper to v12

### DIFF
--- a/carshop/bun.lock
+++ b/carshop/bun.lock
@@ -16,7 +16,7 @@
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.2.3",
         "react-hot-toast": "^2.6.0",
-        "swiper": "^11.2.10",
+        "swiper": "^12.0.3",
         "yet-another-react-lightbox": "^3.28.0",
         "zustand": "^5.0.9",
       },
@@ -843,7 +843,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "swiper": ["swiper@11.2.10", "", {}, "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ=="],
+    "swiper": ["swiper@12.0.3", "", {}, "sha512-BHd6U1VPEIksrXlyXjMmRWO0onmdNPaTAFduzqR3pgjvi7KfmUCAm/0cj49u2D7B0zNjMw02TSeXfinC1hDCXg=="],
 
     "synckit": ["synckit@0.11.11", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw=="],
 

--- a/carshop/package.json
+++ b/carshop/package.json
@@ -24,7 +24,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^19.2.3",
     "react-hot-toast": "^2.6.0",
-    "swiper": "^11.2.10",
+    "swiper": "^12.0.3",
     "yet-another-react-lightbox": "^3.28.0",
     "zustand": "^5.0.9"
   },


### PR DESCRIPTION
## Description
Upgrade `swiper` to v12.

## Why?
Keep the carousel/slider dependency up to date and reduce future upgrade friction.

## Notes
This PR is intentionally scoped to a single dependency upgrade.
