### PR TITLE
chore(env): add env example files for local and docker

### DIFF
--- a/carshop/.env.docker.example
+++ b/carshop/.env.docker.example
@@ -1,0 +1,6 @@
+# MySQL container settings (docker-compose)
+DB_PORT=3306
+DB_USER=example_user
+DB_PASS=example_pass
+DB_NAME=example_db
+DB_ROOT_PASS=example_root_pass

--- a/carshop/.env.example
+++ b/carshop/.env.example
@@ -1,0 +1,11 @@
+# Database (app connection)
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_USER=example_user
+DB_PASS=example_pass
+DB_NAME=example_db
+
+# Email (optional, for mailing)
+EMAIL_USER=example_user
+EMAIL_PASS=example_pass
+OWNER_EMAIL=example_email

--- a/carshop/.gitignore
+++ b/carshop/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.*.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Description
Add `.env.example` and `.env.docker.example` to document required environment
variables for local development and Docker-based setup.

## Why?
Make local setup easier for new contributors while preventing accidental commits
of real secrets by updating `.gitignore` rules.

## Notes
- Real `.env*` files remain ignored.
- Example files are explicitly allowed and kept in the repository.
