### PR TITLE
chore(prettier): ignore next-env.d.ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ dist
 build
 coverage
 *.log
+next-env.d.ts


### PR DESCRIPTION
## Description

This PR adds a small follow-up fix that was missed in the previous merge.

A `.prettierignore` update (`next-env.d.ts`) was committed locally after
PR #15 had already been merged and therefore did not make it into `main`.

The change has now been cherry-picked to ensure consistent formatting
behavior and avoid unnecessary Prettier processing.

---

- PR #15 (**feat: paginated reviews, products page refactor, and responsive UI improvements**)  
  was merged shortly before this commit was created.

---

## Changes

- Ignore `next-env.d.ts` in Prettier config

