### PR TITLE
feat(checkout): add Stripe Checkout session + webhook for orders

### DIFF
--- a/app/api/send-order/route.js
+++ b/app/api/send-order/route.js
@@ -1,12 +1,13 @@
 import { sendOrderEmail } from '@/shared/api/server';
-import { ErrorHandler } from '@/shared/lib';
+import { ErrorHandler, HttpError } from '@/shared/lib';
 
 const handler = async (req) => {
-  const body = await req.json();
+  const body = await req.json().catch(() => null);
+  if (!body) throw new HttpError(400, 'Invalid JSON');
 
   await sendOrderEmail(body);
 
-  return Response.json({ success: true });
+  return Response.json({ ok: true });
 };
 
 export const POST = ErrorHandler(handler);

--- a/app/api/stripe/checkout/route.js
+++ b/app/api/stripe/checkout/route.js
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+
+import { cartItemsToLineItems } from '@/features/order/checkout/lib/stripeMappers';
+import { getAppUrl,stripe } from '@/shared/api/server/stripeClient';
+import { ErrorHandler, HttpError } from '@/shared/lib';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function validateCheckoutBody(body) {
+  const customer = body?.customer;
+  const cartItems = body?.cartItems;
+
+  if (!customer?.name || !customer?.phone || !customer?.email) {
+    throw new HttpError(400, 'Некоректні дані клієнта');
+  }
+
+  return { customer, cartItems };
+}
+
+const handler = async (req) => {
+  const body = await req.json().catch(() => null);
+  if (!body) throw new HttpError(400, 'Invalid JSON');
+
+  const { customer, cartItems } = validateCheckoutBody(body);
+
+  const line_items = cartItemsToLineItems(cartItems, 'uah');
+  const APP_URL = getAppUrl();
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'payment',
+
+    payment_method_types: ['card'],
+
+    line_items,
+
+    success_url: `${APP_URL}/order?payment=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${APP_URL}/order?payment=cancel`,
+
+    customer_email: customer.email,
+
+    metadata: {
+      name: customer.name,
+      phone: customer.phone,
+      comment: customer.comment || '',
+    },
+  });
+
+  return NextResponse.json({ ok: true, url: session.url });
+};
+
+export const POST = ErrorHandler(handler);

--- a/app/api/stripe/session/route.js
+++ b/app/api/stripe/session/route.js
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+
+import { sessionToClientVerification } from '@/features/order/checkout/lib/stripeMappers';
+import { stripe } from '@/shared/api/server/stripeClient';
+import { ErrorHandler, HttpError } from '@/shared/lib';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const handler = async (req) => {
+  const { searchParams } = new URL(req.url);
+  const sessionId = searchParams.get('session_id');
+
+  if (!sessionId) throw new HttpError(400, 'Missing session_id');
+
+  const session = await stripe.checkout.sessions.retrieve(sessionId, {
+    expand: ['line_items'],
+  });
+
+  return NextResponse.json({ ok: true, ...sessionToClientVerification(session) });
+};
+
+export const GET = ErrorHandler(handler);

--- a/app/api/stripe/webhook/route.js
+++ b/app/api/stripe/webhook/route.js
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+
+import { sessionToEmailPayload } from '@/features/order/checkout/lib/stripeMappers';
+import { sendOrderEmail } from '@/shared/api/server';
+import { stripe } from '@/shared/api/server/stripeClient';
+import { ErrorHandler, HttpError } from '@/shared/lib';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const processedEventIds = globalThis.__stripeProcessedEventIds || new Set();
+globalThis.__stripeProcessedEventIds = processedEventIds;
+
+const handler = async (req) => {
+  const sig = req.headers.get('stripe-signature');
+  if (!sig) throw new HttpError(400, 'Missing stripe-signature header');
+
+  const rawBody = await req.text();
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET);
+  } catch (err) {
+    throw new HttpError(400, `Bad signature: ${err?.message || ''}`.trim());
+  }
+
+  if (processedEventIds.has(event.id)) {
+    return NextResponse.json({ ok: true, deduped: true });
+  }
+
+  if (event.type !== 'checkout.session.completed') {
+    return NextResponse.json({ ok: true, ignored: true, type: event.type });
+  }
+
+  processedEventIds.add(event.id);
+
+  const s = event.data.object;
+
+  const fullSession = await stripe.checkout.sessions.retrieve(s.id, {
+    expand: ['line_items'],
+  });
+
+  if (fullSession.payment_status !== 'paid') {
+    return NextResponse.json({ ok: true, skipped: true, reason: 'not_paid' });
+  }
+
+  const emailPayload = sessionToEmailPayload(fullSession);
+
+  await sendOrderEmail({
+    name: emailPayload.name,
+    phone: emailPayload.phone,
+    email: emailPayload.email,
+    comment: emailPayload.comment,
+    cartItems: emailPayload.cartItems,
+    total: emailPayload.total,
+  });
+
+  console.log('✅ PAID (stripe webhook):', {
+    id: fullSession.id,
+    email: emailPayload.email,
+    amount_total: fullSession.amount_total,
+    currency: fullSession.currency,
+  });
+
+  return NextResponse.json({ ok: true });
+};
+
+export const POST = ErrorHandler(handler);

--- a/bun.lock
+++ b/bun.lock
@@ -16,9 +16,10 @@
         "react-device-detect": "^2.2.3",
         "react-dom": "^19.2.3",
         "react-hot-toast": "^2.6.0",
+        "stripe": "^20.2.0",
         "swiper": "^12.0.3",
         "yet-another-react-lightbox": "^3.28.0",
-        "zustand": "^5.0.9",
+        "zustand": "^5.0.9"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -41,9 +42,9 @@
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
         "vite-tsconfig-paths": "^6.0.4",
-        "vitest": "^4.0.17",
-      },
-    },
+        "vitest": "^4.0.17"
+      }
+    }
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
@@ -1046,6 +1047,8 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "qs": ["qs@6.14.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@19.2.3", "", {}, "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA=="],
@@ -1145,6 +1148,8 @@
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "stripe": ["stripe@20.2.0", "", { "dependencies": { "qs": "^6.14.1" }, "peerDependencies": { "@types/node": ">=16" }, "optionalPeers": ["@types/node"] }, "sha512-m8niTfdm3nPP/yQswRWMwQxqEUcTtB3RTJQ9oo6NINDzgi7aPOadsH/fPXIIfL1Sc5+lqQFKSk7WiO6CXmvaeA=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
@@ -1368,6 +1373,6 @@
 
     "eslint-import-resolver-typescript/tinyglobby/fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
 
-    "eslint-import-resolver-typescript/tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
+    "eslint-import-resolver-typescript/tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="]
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-device-detect": "^2.2.3",
     "react-dom": "^19.2.3",
     "react-hot-toast": "^2.6.0",
+    "stripe": "^20.2.0",
     "swiper": "^12.0.3",
     "yet-another-react-lightbox": "^3.28.0",
     "zustand": "^5.0.9"

--- a/src/features/order/checkout/api/createStripeCheckout.js
+++ b/src/features/order/checkout/api/createStripeCheckout.js
@@ -1,0 +1,15 @@
+export async function createStripeCheckout({ customer, cartItems }) {
+  const res = await fetch('/api/stripe/checkout', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ customer, cartItems }),
+  });
+
+  const data = await res.json().catch(() => null);
+
+  if (!res.ok || !data?.ok || !data?.url) {
+    throw new Error(data?.message || 'Failed to create Stripe Checkout Session');
+  }
+
+  return data; // { ok: true, url }
+}

--- a/src/features/order/checkout/lib/stripeMappers.js
+++ b/src/features/order/checkout/lib/stripeMappers.js
@@ -1,0 +1,82 @@
+import { HttpError } from '@/shared/lib';
+
+export function cartItemsToLineItems(cartItems, currency = 'uah') {
+  if (!Array.isArray(cartItems) || cartItems.length === 0) {
+    throw new HttpError(400, 'Кошик порожній');
+  }
+
+  return cartItems.map((item) => {
+    const name = String(item?.name || 'Товар');
+    const quantity = Number(item?.quantity || 1);
+    const price = Number(item?.price || 0);
+
+    if (!Number.isFinite(quantity) || quantity <= 0) {
+      throw new HttpError(400, `Некоректна кількість товару: ${name}`);
+    }
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new HttpError(400, `Некоректна ціна товару: ${name}`);
+    }
+
+    const unit_amount = Math.round(price * 100);
+
+    return {
+      quantity,
+      price_data: {
+        currency,
+        unit_amount,
+        product_data: { name },
+      },
+    };
+  });
+}
+
+export function sessionToCartItems(session) {
+  const lineItems = session?.line_items?.data || [];
+
+  return lineItems.map((li, idx) => {
+    const qty = li.quantity || 1;
+    const unitAmount = li.price?.unit_amount ?? 0;
+
+    const id = li.price?.id || li.id || `li_${session.id}_${idx}`;
+
+    return {
+      id,
+      name: li.description || 'Товар',
+      quantity: qty,
+      price: Number((unitAmount / 100).toFixed(2)),
+    };
+  });
+}
+
+export function sessionToTotal(session) {
+  return Number(((session?.amount_total || 0) / 100).toFixed(2));
+}
+
+export function sessionToEmailPayload(session) {
+  const email = session.customer_details?.email || session.customer_email || '';
+  const name = session.metadata?.name || session.customer_details?.name || '';
+  const phone = session.metadata?.phone || '';
+  const comment = session.metadata?.comment || '';
+
+  return {
+    name,
+    phone,
+    email,
+    comment,
+    cartItems: sessionToCartItems(session).map(({ id, ...rest }) => rest),
+    total: sessionToTotal(session),
+  };
+}
+
+export function sessionToClientVerification(session) {
+  return {
+    paid: session.payment_status === 'paid',
+    id: session.id,
+    currency: session.currency,
+    payment_status: session.payment_status,
+    customer_email: session.customer_details?.email || session.customer_email || null,
+    metadata: session.metadata || {},
+    cartItems: sessionToCartItems(session),
+    total: sessionToTotal(session),
+  };
+}

--- a/src/pages/order/ui/OrderPage.jsx
+++ b/src/pages/order/ui/OrderPage.jsx
@@ -1,7 +1,19 @@
 'use client';
 
+import { Suspense } from 'react';
+
 import OrderCheckout from '@/widgets/order-checkout';
 
+import PaymentBanner from './PaymentBanner';
+
 export default function OrderPage() {
-  return <OrderCheckout />;
+  return (
+    <>
+      <Suspense fallback={null}>
+        <PaymentBanner />
+      </Suspense>
+
+      <OrderCheckout />
+    </>
+  );
 }

--- a/src/pages/order/ui/PaymentBanner.jsx
+++ b/src/pages/order/ui/PaymentBanner.jsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+export default function PaymentBanner() {
+  const sp = useSearchParams();
+  const payment = sp.get('payment');
+
+  if (!payment) return null;
+
+  if (payment === 'success') {
+    return (
+      <div className="mx-auto max-w-2xl mt-6 mb-2 px-4">
+        <div className="rounded-xl bg-lime-100 text-lime-900 p-4">
+          ✅ Оплата пройшла (test). Дякуємо!
+        </div>
+      </div>
+    );
+  }
+
+  if (payment === 'cancel') {
+    return (
+      <div className="mx-auto max-w-2xl mt-6 mb-2 px-4">
+        <div className="rounded-xl bg-yellow-100 text-yellow-900 p-4">
+          ⚠️ Оплату скасовано. Ви можете спробувати ще раз.
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/shared/api/server/stripeClient.js
+++ b/src/shared/api/server/stripeClient.js
@@ -1,0 +1,9 @@
+import 'server-only';
+
+import Stripe from 'stripe';
+
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
+
+export function getAppUrl() {
+  return process.env.APP_URL || 'http://localhost:3000';
+}

--- a/src/shared/lib/errorHandler.js
+++ b/src/shared/lib/errorHandler.js
@@ -1,12 +1,25 @@
+import { NextResponse } from 'next/server';
+
+import { HttpError } from './httpError';
+
 export function ErrorHandler(handler) {
   return async function (request, context) {
     try {
       return await handler(request, context);
     } catch (err) {
-      console.error('API Error:', err);
-      return new Response(JSON.stringify({ error: 'Internal server error' }), {
-        status: 500,
+      const status = err instanceof HttpError ? err.status : 500;
+
+      console.error('API Error:', {
+        message: err?.message,
+        name: err?.name,
+        status,
+        stack: err?.stack,
       });
+
+      return NextResponse.json(
+        { ok: false, message: err?.message || 'Internal server error' },
+        { status },
+      );
     }
   };
 }

--- a/src/shared/lib/httpError.js
+++ b/src/shared/lib/httpError.js
@@ -1,0 +1,7 @@
+export class HttpError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.name = 'HttpError';
+    this.status = status;
+  }
+}

--- a/src/shared/lib/index.js
+++ b/src/shared/lib/index.js
@@ -2,6 +2,7 @@ export { cx } from './cx';
 export * from './emailTemplates';
 export { ErrorHandler } from './errorHandler';
 export * from './formatDateUA';
+export { HttpError } from './httpError';
 export { isOpenNow } from './isOpenNow';
 export { normalize } from './normalize';
 export { useSmartHeader } from './useSmartHeader';

--- a/src/widgets/order-checkout/model/useOrderCheckout.js
+++ b/src/widgets/order-checkout/model/useOrderCheckout.js
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+
+import { useCartStore } from '@/features/cart';
+import { useCheckout } from '@/features/order/checkout';
+
+
+export function useOrderCheckout() {
+  const { cartItems, total, form, onChange, submit, isSubmitting } = useCheckout();
+  const { clearCart, saveOrder } = useCartStore();
+
+  const [submittedOrder, setSubmittedOrder] = useState(null);
+  const [verifying, setVerifying] = useState(false);
+
+  const stripeReturn = useMemo(() => {
+    if (typeof window === 'undefined') return { payment: null, sessionId: null };
+    const params = new URLSearchParams(window.location.search);
+    return {
+      payment: params.get('payment'),
+      sessionId: params.get('session_id'),
+    };
+  }, []);
+
+  useEffect(() => {
+    const { payment, sessionId } = stripeReturn;
+    if (payment !== 'success' || !sessionId) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        setVerifying(true);
+
+        const res = await fetch(`/api/stripe/session?session_id=${encodeURIComponent(sessionId)}`);
+        const data = await res.json().catch(() => null);
+
+        if (!res.ok || !data) throw new Error(data?.message || 'Failed to verify payment');
+
+        if (!data.paid) {
+          alert('Оплата не підтверджена. Якщо гроші списались — зверніться до менеджера.');
+          return;
+        }
+
+        const orderData = {
+          items: data.cartItems || [],
+          total: data.total ?? 0,
+          name: data.metadata?.name || '',
+          phone: data.metadata?.phone || '',
+          email: data.customer_email || '',
+          comment: data.metadata?.comment || '',
+          createdAt: new Date().toISOString(),
+          paid: true,
+          stripeSessionId: data.id,
+        };
+
+        if (cancelled) return;
+
+        saveOrder(orderData);
+
+        clearCart();
+
+        setSubmittedOrder(orderData);
+
+        window.history.replaceState({}, '', '/order');
+      } catch (e) {
+        console.error(e);
+        alert('Не вдалося підтвердити оплату. Спробуйте оновити сторінку.');
+      } finally {
+        if (!cancelled) setVerifying(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [stripeReturn, clearCart, saveOrder]);
+
+  const onSubmit = async (e) => {
+    const res = await submit(e);
+    if (!res?.ok) alert(res?.message || 'Помилка');
+  };
+
+  return {
+    cartItems,
+    total,
+    form,
+    onChange,
+    isSubmitting,
+
+    verifying,
+    submittedOrder,
+
+    onSubmit,
+  };
+}

--- a/src/widgets/order-checkout/ui/CheckoutForm.jsx
+++ b/src/widgets/order-checkout/ui/CheckoutForm.jsx
@@ -3,6 +3,8 @@
 import { motion } from 'framer-motion';
 
 export default function CheckoutForm({ cartItems, total, form, onChange, onSubmit, isSubmitting }) {
+  const safeItems = Array.isArray(cartItems) ? cartItems : [];
+
   return (
     <div className="min-h-screen flex items-center justify-center px-4 py-10">
       <div className="w-full max-w-2xl bg-white rounded-lg shadow-2xl p-6 space-y-6">
@@ -13,16 +15,25 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="border-t" />
 
         <ul className="space-y-2 text-gray-800 text-sm">
-          {cartItems.map((item) => (
-            <li key={item.id} className="grid grid-cols-[1fr_auto] gap-4 items-start">
-              <span>
-                {item.name} {item.quantity} шт.
-              </span>
-              <span className="text-gray-900 font-semibold text-right min-w-15">
-                {item.price * item.quantity} ₴
-              </span>
-            </li>
-          ))}
+          {safeItems.map((item, idx) => {
+            const name = item?.name ?? 'Товар';
+            const qty = Number(item?.quantity ?? 1);
+            const price = Number(item?.price ?? 0);
+            const lineTotal = price * qty;
+
+            const key = item?.id ? String(item.id) : `${name}-${idx}`;
+
+            return (
+              <li key={key} className="grid grid-cols-[1fr_auto] gap-4 items-start">
+                <span>
+                  {name} {qty} шт.
+                </span>
+                <span className="text-gray-900 font-semibold text-right min-w-15">
+                  {lineTotal} ₴
+                </span>
+              </li>
+            );
+          })}
         </ul>
 
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="border-t" />
@@ -35,7 +46,7 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
           <span className="font-bold">{total} ₴</span>
         </div>
 
-        <form onSubmit={onSubmit} className="space-y-4">
+        <form onSubmit={onSubmit} className="space-y-4" aria-busy={isSubmitting}>
           <input
             required
             type="text"
@@ -43,7 +54,8 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
             placeholder="Введіть ваше ім’я*"
             value={form.name}
             onChange={onChange}
-            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition"
+            disabled={isSubmitting}
+            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition disabled:opacity-70"
           />
 
           <input
@@ -53,7 +65,8 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
             placeholder="Номер телефону*"
             value={form.phone}
             onChange={onChange}
-            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition"
+            disabled={isSubmitting}
+            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition disabled:opacity-70"
           />
 
           <input
@@ -63,7 +76,8 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
             placeholder="Email*"
             value={form.email}
             onChange={onChange}
-            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition"
+            disabled={isSubmitting}
+            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition disabled:opacity-70"
           />
 
           <textarea
@@ -71,26 +85,26 @@ export default function CheckoutForm({ cartItems, total, form, onChange, onSubmi
             placeholder="Коментар до замовлення (необов’язково)"
             value={form.comment}
             onChange={onChange}
-            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition min-h-25"
+            disabled={isSubmitting}
+            className="w-full border border-gray-400 rounded-xl px-4 py-3 text-gray-900 placeholder:text-gray-500 focus:outline-none focus:ring-2 focus:ring-lime-500 transition min-h-25 disabled:opacity-70"
           />
 
           <button
             type="submit"
             disabled={isSubmitting}
+            aria-disabled={isSubmitting}
             className={`cursor-pointer w-full text-white font-semibold py-3 rounded-xl transition ${
               isSubmitting
                 ? 'bg-gray-400 cursor-not-allowed'
-                : 'bg-gray-900 hover:bg-gray-800 transition duration-200 shadow-md'
+                : 'bg-lime-600 hover:bg-lime-700 transition duration-200 shadow-md'
             }`}
           >
-            {isSubmitting ? 'Обробка...' : 'Підтвердити замовлення'}
+            {isSubmitting ? 'Переходимо до оплати...' : 'Оплатити карткою (Stripe test)'}
           </button>
 
-          <div className="text-sm text-gray-900">
-            Натискаючи «Підтвердити замовлення», ви нічого не сплачуєте - менеджер отримає
-            інформацію про ваше замовлення та зв’яжеться з вами найближчим часом для уточнення
-            деталей, розрахунку вартості доставки та оплати
-            <span className="text-red-500 ml-0.5">*</span>
+          <div className="text-sm text-gray-600">
+            Після натискання ви будете перенаправлені на сторінку Stripe Checkout (test mode). Лист
+            про замовлення надсилається після підтвердження оплати.
           </div>
         </form>
       </div>

--- a/src/widgets/order-checkout/ui/OrderCheckout.jsx
+++ b/src/widgets/order-checkout/ui/OrderCheckout.jsx
@@ -1,17 +1,25 @@
 'use client';
 
-import { useCheckout } from '@/features/order/checkout';
-
+import { useOrderCheckout } from '../model/useOrderCheckout';
 import CheckoutForm from './CheckoutForm';
 import CheckoutSuccess from './CheckoutSuccess';
 
 export default function OrderCheckout() {
-  const { cartItems, total, form, onChange, submit, isSubmitting, submittedOrder } = useCheckout();
+  const { cartItems, total, form, onChange, isSubmitting, verifying, submittedOrder, onSubmit } =
+    useOrderCheckout();
 
-  const onSubmit = async (e) => {
-    const res = await submit(e);
-    if (!res?.ok) alert(res?.message || 'Помилка');
-  };
+  if (verifying) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4 py-10">
+        <div className="w-full max-w-md bg-white rounded-lg shadow-2xl p-6 text-center space-y-3">
+          <div className="text-2xl font-bold text-gray-900">Підтверджуємо оплату…</div>
+          <div className="text-gray-600 text-sm">
+            Це займає кілька секунд. Не закривайте сторінку.
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (submittedOrder) return <CheckoutSuccess order={submittedOrder} />;
 


### PR DESCRIPTION
# feat(checkout): integrate Stripe Checkout flow (test mode)

## Description

This PR migrates the order flow to **Stripe Checkout (test mode)**.

Instead of submitting an order directly from the UI, the checkout form
now creates a Stripe Checkout session and redirects the customer to
Stripe-hosted payment.\
After payment, the app verifies the session and finalizes the order.

---

## What's done

### Stripe Checkout integration

-   Added `POST /api/stripe/checkout` to create a Stripe Checkout
    session and return a redirect URL
-   Added `GET /api/stripe/session` to fetch session + line items and
    confirm payment status
-   Added `POST /api/stripe/webhook` to handle
    `checkout.session.completed` and trigger post-payment side effects

---

### Checkout UX improvements

-   Checkout submit redirects to Stripe Checkout
-   Added client-side verification on return
    (`/order?payment=success&session_id=...`)
-   Added `PaymentBanner` for success/cancel states
-   Improved form safety:
    -   disabled inputs while submitting
    -   `aria-busy` on submit
    -   safer mapping for cart items / keys

---

### Infrastructure / dependencies / error handling

- Added Stripe SDK (`stripe@20.2.0`) and server client initialization
- Introduced `HttpError` and improved API error handling responses
  (`ok: false` + message)

---

## Why

-   Stripe Checkout reduces payment handling complexity and risk
-   Keeps checkout flow robust and scalable
-   Allows order finalization to happen only after confirmed payment

---

## How to test

``` bash
bun install
bun run dev
```

### Required env

-   `STRIPE_SECRET_KEY`
-   `STRIPE_WEBHOOK_SECRET`
-   `APP_URL` (optional locally)

### Smoke checks

- `/order` — submit checkout, redirect to Stripe Checkout
-   Complete a test payment → app returns to `/order?payment=success...`
-   Order is saved and cart is cleared after successful payment
    confirmation
-   Webhook receives `checkout.session.completed` and triggers order
    email sending

---

## Notes

-   Consider stronger webhook idempotency (persistent storage) for
    multi-instance deployments
-   Add stricter request validation for `cartItems` on the API boundary
